### PR TITLE
0.2.0 Support cache updates based on optimistic responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # apollo-link-watched-mutation
-A Link interface for providing default cache updates to mutation - query relationships
+A Link interface for providing default cache updates based on { mutation : query } relationships
 
 ### Setup
 
@@ -18,13 +18,14 @@ Easy [client-side caching](https://www.apollographql.com/docs/react/basics/cachi
 
 One of the best features of the apollo-client is the idea of automatic cache updates. Since the apollo-client handles your networking for you, it can inspect traffic and update its cache in-place if it ever sees an updated version of a cached value in a response.
 
-However, there are scenarios (e.g. item creation or filtered lists) where an in-place update may NOT be sufficient.
+However, there are scenarios (e.g. item creation, deletion, filtered lists, etc.) where an in-place update may **not** be sufficient.
 
 Now, Apollo also offers some ways around this, notably in the form of an [update variable](https://www.apollographql.com/docs/react/features/caching.html#updating-the-cache-after-a-mutation), which provides direct-access to the apollo-cache.
 
-However, this update variable doesn't scale very well (in terms of maintainability) in a couple scenarios.
+However, this update variable doesn't scale very well (in terms of developer maintainability) in a couple scenarios.
 1. As the number of queries to update grows, you need knowledge of all of their cache keys in order to keep them updated. In the case of variable lists which aren't predefined, this means you also need to store all of their variables in order to read and update their cached values.
 2. As the number of places where you call the same or similar mutations grows, you need to replicate or find a good general pattern to recreate all of the cacheKey storing and updating logic described above.
+3. You need to, to some extent, embed this logic inside your components, conflating your view with your caching layer even though you could declare the caching behavior you want on start-up.
 ```javascript
 // This update becomes a lot more complex if...
 // 1. we have a variable # of cached filtered lists of todos based off status and other variables (instead of one predetermined list to update)
@@ -52,12 +53,12 @@ new WatchedMutationLink(
   }
 )
 ```
-By adding this WatchedMutationLink to our networking stack, the exported apollo-client would invoke the callback provided for each cached query named "TodoList" whenever a successful mutation named "SaveTodo" is received. If the WatchedMutationLink receives an updated form of the cached data from the callback, it will write that updated data to the cache.
+By adding this WatchedMutationLink to our networking stack, the exported apollo-client would invoke the callback provided for each cached query named *TodoList* whenever a successful mutation named *SaveTodo* is received. If the WatchedMutationLink receives an updated form of the cached data from the callback, it will write that updated data to the cache.
 
 By monitoring networking traffic, the Link figures out when you may want to update your cache based off a mutation and query and you determine how it should update all in one place.
 
 #### Example usage
-The WatchedMutationLink below would manage any # of cached TodoLists after any successful SaveTodo mutation by determining whether or not the mutatedTodo remains relevant on the list and updating the cache if necessary.
+The WatchedMutationLink below would manage any # of cached *TodoList*s after any successful *SaveTodo* mutation (including optimistic mutations & any reversions due to an error) by determining whether or not the mutatedTodo remains relevant on the list and updating the cache if necessary.
 ```graphql
 query TodoList($status: String) {
   todoList(status: $status) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-link-watched-mutation",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An interface for providing default updates for mutation - query pairings",
   "keywords": [
     "apollo",
@@ -31,6 +31,9 @@
     "build": "npm run build:main && npm run build:module",
     "prepublishOnly": "npm test && npm run clean && npm run build",
     "test": "jest"
+  },
+  "jest": {
+    "testRegex": "(/__tests__/.*(test))\\.js$"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0-beta.32",

--- a/src/__tests__/private.js
+++ b/src/__tests__/private.js
@@ -1,0 +1,70 @@
+import gql from 'graphql-tag';
+
+export const sampleQuery = gql`
+    query TodoList($status: String) {
+        todoList(status: $status) {
+            id
+            name
+            status
+        }
+    }
+`;
+
+export const sampleSuccessfulQueryResponse = {
+  data: {
+    todoList: [
+      { id: '1', name: 'Get groceries', status: 'IN_PROGRESS' },
+      { id: '2', name: 'Take car in for service', status: 'DONE' }
+    ]
+  }
+};
+
+export const sampleErrorQueryResponse = {
+  data: null,
+  errors: [{ message: 'Everything went wrong' }]
+};
+
+export const sampleMutation = gql`
+    mutation SaveTodo(
+      $id: String
+      $status: String
+    ) {
+        saveTodo(
+          id: $id
+          status: $status
+        ) {
+            id
+            name
+            status
+        }
+    }
+`;
+
+export const sampleSuccessfulMutationResponse = {
+  data: {
+    saveTodo: {
+      id: '1',
+      name: 'Get groceries',
+      status: 'DONE'
+    }
+  }
+};
+
+export const sampleErrorMutationResponse = {
+  data: null,
+  errors: [{ message: 'Oops forgot to implement' }]
+};
+
+
+export const query = {
+  query: sampleQuery,
+  variables: { status: 'DONE' }
+};
+export const mutation = {
+  query: sampleMutation,
+  variables: { id: 'todo_1', status: 'IN_PROGRESS' }
+};
+export const cache = {
+  readQuery: k => {},
+  writeQuery: (k, v) => {}
+};

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -26,10 +26,10 @@ describe('WatchedMutationLink', () => {
       watchedMutationLink,
       mockLink
     ]);
-    expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
+    expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(false);
 
     execute(link, query).subscribe(() => {
-      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
+      expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(false);
       expect(called).toBe(false);
       done();
     });
@@ -47,7 +47,7 @@ describe('WatchedMutationLink', () => {
       watchedMutationLink,
       mockLink
     ]);
-    expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
+    expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(false);
     const usersQuery = gql`
         query Users {
           id
@@ -56,13 +56,13 @@ describe('WatchedMutationLink', () => {
     `;
 
     execute(link, { query: usersQuery }).subscribe(() => {
-      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
+      expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(false);
       expect(called).toBe(false);
       done();
     });
   });
 
-  it('should add successful and related queries to queriesToUpdate', done => {
+  it('should add successful and related queries to queryManager', done => {
     let called = false;
     const watchedMutationLink = new WatchedMutationLink(cache, {
       SaveTodo: { TodoList: () => { called = true; } }
@@ -72,11 +72,11 @@ describe('WatchedMutationLink', () => {
       watchedMutationLink,
       mockLink
     ]);
-    expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
+    expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(false);
 
     execute(link, query).subscribe(() => {
-      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(true);
-      const todoListQueriesToUpdate = watchedMutationLink.queriesToUpdate.getQueryKeysToUpdate('TodoList');
+      expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(true);
+      const todoListQueriesToUpdate = watchedMutationLink.queryManager.getQueryKeysToUpdate('TodoList');
       expect(todoListQueriesToUpdate.length).toBe(1);
       expect(todoListQueriesToUpdate[0].variables).toMatchObject({ status: 'DONE' });
       expect(called).toBe(false);
@@ -96,11 +96,11 @@ describe('WatchedMutationLink', () => {
       mockQueryLink
     ]);
 
-    expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
+    expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(false);
 
     execute(queryLink, query).subscribe(() => {
-      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(true);
-      const todoListQueriesToUpdate = watchedMutationLink.queriesToUpdate.getQueryKeysToUpdate('TodoList');
+      expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(true);
+      const todoListQueriesToUpdate = watchedMutationLink.queryManager.getQueryKeysToUpdate('TodoList');
       expect(todoListQueriesToUpdate.length).toBe(1);
       expect(todoListQueriesToUpdate[0].variables).toMatchObject({ status: 'DONE' });
       expect(called).toBe(false);
@@ -136,11 +136,11 @@ describe('WatchedMutationLink', () => {
       mockQueryLink
     ]);
 
-    expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
+    expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(false);
 
     execute(queryLink, query).subscribe(() => {
-      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(true);
-      const todoListQueriesToUpdate = watchedMutationLink.queriesToUpdate['TodoList'];
+      expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(true);
+      const todoListQueriesToUpdate = watchedMutationLink.queryManager.getQueryKeysToUpdate('TodoList');
       expect(todoListQueriesToUpdate.length).toBe(1);
       expect(todoListQueriesToUpdate[0].variables).toMatchObject({ status: 'DONE' });
       expect(called).toBe(false);
@@ -203,11 +203,11 @@ describe('WatchedMutationLink', () => {
       mockQueryLink
     ]);
 
-    expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
+    expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(false);
 
     execute(queryLink, query).subscribe(() => {
-      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(true);
-      const todoListQueriesToUpdate = watchedMutationLink.queriesToUpdate['TodoList'];
+      expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(true);
+      const todoListQueriesToUpdate = watchedMutationLink.queryManager.getQueryKeysToUpdate('TodoList');
       expect(todoListQueriesToUpdate.length).toBe(1);
       expect(todoListQueriesToUpdate[0].variables).toMatchObject({ status: 'DONE' });
       expect(called).toBe(false);
@@ -243,11 +243,11 @@ describe('WatchedMutationLink', () => {
         mockQueryLink
       ]);
 
-      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
+      expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(false);
 
       execute(queryLink, query).subscribe(() => {
-        expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(true);
-        const todoListQueriesToUpdate = watchedMutationLink.queriesToUpdate['TodoList'];
+        expect(watchedMutationLink.queryManager.hasQueryToUpdate('TodoList')).toBe(true);
+        const todoListQueriesToUpdate = watchedMutationLink.queryManager.getQueryKeysToUpdate('TodoList');
         expect(todoListQueriesToUpdate.length).toBe(1);
         expect(todoListQueriesToUpdate[0].variables).toMatchObject({ status: 'DONE' });
         expect(called).toBe(false);

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -5,75 +5,15 @@ import {
 } from 'apollo-link';
 import { WatchedMutationLink } from '../index';
 import gql from 'graphql-tag';
-
-
-const sampleQuery = gql`
-    query TodoList($status: String) {
-        todoList(status: $status) {
-            id
-            name
-            status
-        }
-    }
-`;
-
-const sampleSuccessfulQueryResponse = {
-  data: {
-    todoList: [
-      { id: '1', name: 'Get groceries', status: 'IN_PROGRESS' },
-      { id: '2', name: 'Take car in for service', status: 'DONE' }
-    ]
-  }
-};
-
-const sampleErrorQueryResponse = {
-  data: null,
-  errors: [{ message: 'Everything went wrong' }]
-};
-
-const sampleMutation = gql`
-    mutation SaveTodo(
-      $id: String
-      $status: String
-    ) {
-        saveTodo(
-          id: $id
-          status: $status
-        ) {
-            id
-            name
-            status
-        }
-    }
-`;
-
-const sampleSuccessfulMutationResponse = {
-  data: {
-    saveTodo: {
-      id: '1',
-      name: 'Get groceries',
-      status: 'DONE'
-    }
-  }
-};
-
-const sampleErrorMutationResponse = {
-  data: null,
-  errors: [{ message: 'Oops forgot to implement' }]
-};
-
-const query = {
-  query: sampleQuery,
-  variables: { status: 'DONE' }
-};
-const mutation = {
-  query: sampleMutation,
-  variables: { id: 'todo_1', status: 'IN_PROGRESS' }
-};
-const cache = {
-  readQuery: k => {},
-  writeQuery: (k, v) => {}
-};
+import {
+  sampleSuccessfulQueryResponse,
+  sampleErrorQueryResponse,
+  sampleSuccessfulMutationResponse,
+  sampleErrorMutationResponse,
+  cache,
+  mutation,
+  query
+} from './private';
 
 describe('WatchedMutationLink', () => {
   it('should ignore unsuccessful queries', done => {
@@ -86,10 +26,10 @@ describe('WatchedMutationLink', () => {
       watchedMutationLink,
       mockLink
     ]);
-    expect(watchedMutationLink.queriesToUpdate.hasOwnProperty('TodoList')).toBe(false);
+    expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
 
     execute(link, query).subscribe(() => {
-      expect(watchedMutationLink.queriesToUpdate.hasOwnProperty('TodoList')).toBe(false);
+      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
       expect(called).toBe(false);
       done();
     });
@@ -107,7 +47,7 @@ describe('WatchedMutationLink', () => {
       watchedMutationLink,
       mockLink
     ]);
-    expect(watchedMutationLink.queriesToUpdate.hasOwnProperty('TodoList')).toBe(false);
+    expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
     const usersQuery = gql`
         query Users {
           id
@@ -116,7 +56,7 @@ describe('WatchedMutationLink', () => {
     `;
 
     execute(link, { query: usersQuery }).subscribe(() => {
-      expect(watchedMutationLink.queriesToUpdate.hasOwnProperty('TodoList')).toBe(false);
+      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
       expect(called).toBe(false);
       done();
     });
@@ -132,11 +72,11 @@ describe('WatchedMutationLink', () => {
       watchedMutationLink,
       mockLink
     ]);
-    expect(watchedMutationLink.queriesToUpdate.hasOwnProperty('TodoList')).toBe(false);
+    expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
 
     execute(link, query).subscribe(() => {
-      expect(watchedMutationLink.queriesToUpdate.hasOwnProperty('TodoList')).toBe(true);
-      const todoListQueriesToUpdate = watchedMutationLink.queriesToUpdate['TodoList'];
+      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(true);
+      const todoListQueriesToUpdate = watchedMutationLink.queriesToUpdate.getQueryKeysToUpdate('TodoList');
       expect(todoListQueriesToUpdate.length).toBe(1);
       expect(todoListQueriesToUpdate[0].variables).toMatchObject({ status: 'DONE' });
       expect(called).toBe(false);
@@ -149,10 +89,32 @@ describe('WatchedMutationLink', () => {
     const watchedMutationLink = new WatchedMutationLink(cache, {
       SaveTodo: { TodoList: () => { called = true; } }
     });
-    const mockLink = new ApolloLink(() => Observable.of(sampleErrorMutationResponse));
+    const mockQueryLink = new ApolloLink(() => Observable.of(sampleSuccessfulQueryResponse));
+    const mockMutationLink = new ApolloLink(() => Observable.of(sampleErrorMutationResponse));
+    const queryLink = ApolloLink.from([
+      watchedMutationLink,
+      mockQueryLink
+    ]);
+
+    expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
+
+    execute(queryLink, query).subscribe(() => {
+      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(true);
+      const todoListQueriesToUpdate = watchedMutationLink.queriesToUpdate.getQueryKeysToUpdate('TodoList');
+      expect(todoListQueriesToUpdate.length).toBe(1);
+      expect(todoListQueriesToUpdate[0].variables).toMatchObject({ status: 'DONE' });
+      expect(called).toBe(false);
+    });
+
+    // mock what should be stored in apollo's cache after a successful query
+    watchedMutationLink.cache.read = cacheKey => {
+      if (JSON.stringify(cacheKey) === JSON.stringify(query)) {
+        return sampleErrorQueryResponse;
+      }
+    }
     const link = ApolloLink.from([
       watchedMutationLink,
-      mockLink
+      mockMutationLink
     ]);
     execute(link, mutation).subscribe(() => {
       expect(called).toBe(false);
@@ -165,12 +127,36 @@ describe('WatchedMutationLink', () => {
     const watchedMutationLink = new WatchedMutationLink(cache, {
       SaveTodo: { TodoList: () => { called = true; } }
     });
-    const mockLink = new ApolloLink(() => Observable.of({
+    const mockQueryLink = new ApolloLink(() => Observable.of(sampleSuccessfulQueryResponse));
+    const mockMutationLink = new ApolloLink(() => Observable.of({
       data: { saveUser: { id: 'foo', name: 'Joh' }}
     }));
+    const queryLink = ApolloLink.from([
+      watchedMutationLink,
+      mockQueryLink
+    ]);
+
+    expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
+
+    execute(queryLink, query).subscribe(() => {
+      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(true);
+      const todoListQueriesToUpdate = watchedMutationLink.queriesToUpdate['TodoList'];
+      expect(todoListQueriesToUpdate.length).toBe(1);
+      expect(todoListQueriesToUpdate[0].variables).toMatchObject({ status: 'DONE' });
+      expect(called).toBe(false);
+    });
+
+    // mock what should be stored in apollo's cache after a successful query
+    watchedMutationLink.cache.read = cacheKey => {
+      if (JSON.stringify(cacheKey) === JSON.stringify(query)) {
+        return sampleErrorQueryResponse;
+      }
+    }
+
+
     const link = ApolloLink.from([
       watchedMutationLink,
-      mockLink
+      mockMutationLink
     ]);
     const usersMutation = gql`
         mutation SaveUser(
@@ -217,10 +203,10 @@ describe('WatchedMutationLink', () => {
       mockQueryLink
     ]);
 
-    expect(watchedMutationLink.queriesToUpdate.hasOwnProperty('TodoList')).toBe(false);
+    expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
 
     execute(queryLink, query).subscribe(() => {
-      expect(watchedMutationLink.queriesToUpdate.hasOwnProperty('TodoList')).toBe(true);
+      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(true);
       const todoListQueriesToUpdate = watchedMutationLink.queriesToUpdate['TodoList'];
       expect(todoListQueriesToUpdate.length).toBe(1);
       expect(todoListQueriesToUpdate[0].variables).toMatchObject({ status: 'DONE' });
@@ -228,7 +214,7 @@ describe('WatchedMutationLink', () => {
     });
 
     // mock what should be stored in apollo's cache after a successful query
-    watchedMutationLink.cache.readQuery = cacheKey => {
+    watchedMutationLink.cache.read = cacheKey => {
       if (JSON.stringify(cacheKey) === JSON.stringify(query)) {
         return sampleErrorQueryResponse;
       }
@@ -243,4 +229,49 @@ describe('WatchedMutationLink', () => {
       done();
     });
   });
+
+
+  describe('optimistic', () => {
+    it('should invoke the provided callback if a cached query exist for a watched mutation and an optimistic response is sent', done => {
+      let called = false;
+      const watchedMutationLink = new WatchedMutationLink(cache, {
+        SaveTodo: { TodoList: () => { called = true; } }
+      });
+      const mockQueryLink = new ApolloLink(() => Observable.of(sampleSuccessfulQueryResponse));
+      const queryLink = ApolloLink.from([
+        watchedMutationLink,
+        mockQueryLink
+      ]);
+
+      expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(false);
+
+      execute(queryLink, query).subscribe(() => {
+        expect(watchedMutationLink.queriesToUpdate.hasQueryToUpdate('TodoList')).toBe(true);
+        const todoListQueriesToUpdate = watchedMutationLink.queriesToUpdate['TodoList'];
+        expect(todoListQueriesToUpdate.length).toBe(1);
+        expect(todoListQueriesToUpdate[0].variables).toMatchObject({ status: 'DONE' });
+        expect(called).toBe(false);
+      });
+
+      // mock what should be stored in apollo's cache after a successful query
+      watchedMutationLink.cache.read = cacheKey => {
+        if (JSON.stringify(cacheKey) === JSON.stringify(query)) {
+          return sampleErrorQueryResponse;
+        }
+      }
+      const mutationLink = ApolloLink.from([
+        watchedMutationLink,
+        new ApolloLink(() => {})
+      ]);
+
+      execute(mutationLink, {
+        ...mutation,
+        context: {
+          optimisticResponse: { ...sampleSuccessfulMutationResponse.data }
+        }
+      });
+      expect(called).toBe(true);
+      done();
+    });
+  })
 });

--- a/src/cache-manager.js
+++ b/src/cache-manager.js
@@ -1,0 +1,49 @@
+export const createCacheManager = (cache, debug, readOnly) => {
+  return {
+    createKey: operation => ({ query: operation.query, variables: operation.variables }),
+    read: query => {
+      try {
+        return cache.readQuery(query);
+      } catch (error) {
+        if (debug) {
+          window.console.log({
+            message: 'Error --- Unable to read from cache',
+            cacheKey: query,
+            error
+          });
+        }
+      }
+    },
+    write: (query, data) => {
+      if (readOnly) {
+        if (debug) {
+          window.console.log({
+            message: 'ReadOnly --- this link will NOT write to the cache but it would have attempted to',
+            cacheKey: query,
+            data
+          });
+        }
+        return;
+      }
+      try {
+        cache.writeQuery({ ...query, data });
+        if (debug) {
+          window.console.log({
+            message: 'Success --- Updated the cache upon a mutation',
+            cacheKey: query,
+            data
+          });
+        }
+      } catch (error) {
+        if (debug) {
+          window.console.log({
+            message: 'Error --- Unable to write to the cache',
+            cacheKey: query,
+            data,
+            error
+          });
+        }
+      }
+    }
+  };
+};

--- a/src/cache-manager.js
+++ b/src/cache-manager.js
@@ -28,11 +28,16 @@ export const createCacheManager = (cache, debug, readOnly) => {
       try {
         cache.writeQuery({ ...query, data });
         if (debug) {
-          window.console.log({
-            message: 'Success --- Updated the cache upon a mutation',
-            cacheKey: query,
-            data
-          });
+          const writtenData = cache.readQuery(query);
+          if (JSON.stringify(data) === JSON.stringify(writtenData)) {
+            window.console.log({
+              message: 'Success --- Updated the cache upon a mutation',
+              cacheKey: query,
+              data
+            });
+          } else {
+            throw new Error('Unable to write to the cache');
+          }
         }
       } catch (error) {
         if (debug) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,16 @@ import { assertPreconditions } from './validation';
 import {
   isSuccessfulQuery,
   isSuccessfulMutation,
-  getQueryName
+  isFailedMutation,
+  isOptimistic,
+  getQueryName,
+  getLinkArgs
 } from './utils';
+import { createCacheManager } from './cache-manager';
+import { createQueryKeyManager } from './queries-to-update-manager';
+import { createMutationsManager } from './mutations-to-update-manager';
+import { createInflightRequestManager } from './inflight-request-manager';
+
 
 export class WatchedMutationLink extends ApolloLink {
   /**
@@ -14,65 +22,45 @@ export class WatchedMutationLink extends ApolloLink {
    * @param debug - flag for debug logging, will log if truthy
    * @param readOnly - flag for telling this link never to write to the cache but otherwise operate as normal
    */
-  constructor(cache, mutationQueryResolverMap, debug = 0, readOnly = 0) {
-    assertPreconditions(cache, mutationQueryResolverMap);
+  constructor(...args) {
     super();
-    this.cache = cache;
+    const {
+      cache,
+      mutationQueryResolverMap,
+      debug,
+      readOnly
+    } = getLinkArgs(...args);
+
+    assertPreconditions(cache, mutationQueryResolverMap);
+
+    this.cache = createCacheManager(cache, debug, readOnly);
     this.debug = debug;
     this.readOnly = readOnly;
-    // used to look up mutations to watch, what queries each mutation is related to, and what callbacks to call for each query
-    this.mutationQueryResolverMap = mutationQueryResolverMap;
-    // used keep track of unique QueryName + QueryCacheKey combinations
-    // structured as { Query: [cache_key_1, cache_key_2, ...] }
-    this.queriesToUpdate = {};
-    this.debugLog({ message: 'Success --- Constructed our link', watchedMutationNames: Object.keys(this.mutationQueryResolverMap)});
+    this.mutationManager = createMutationsManager(mutationQueryResolverMap);
+    this.queriesToUpdate = createQueryKeyManager();
+    this.inflightOptimisticRequests = createInflightRequestManager(this.cache);
+    this.debugLog({
+      message: 'Success --- Constructed our link',
+      watchedMutations: this.mutationManager.getMutationNames()
+    });
   }
 
   debugLog = payload => this.debug && window.console.log(payload);
-  readFromCache = cacheKey => {
-    try {
-      return this.cache.readQuery(cacheKey);
-    } catch (error) {
-      this.debugLog({ message: 'Error --- Unable to read from cache', cacheKey, error });
-    }
-  }
-  writeToCache = (cacheKey, data) => {
-    if (this.readOnly) {
-      this.debugLog({ message: 'ReadOnly --- this link will NOT write to the cache but it would have attempted to', cacheKey, data });
-      return;
-    }
-    try {
-      this.cache.writeQuery({ ...cacheKey, data });
-      this.debugLog({ message: 'Success --- Updated the cache upon a mutation', cacheKey, data });
-    } catch (error) {
-      this.debugLog({ message: 'Error --- Unable to write to the cache', cacheKey, data, error });
-    }
-  }
-
   isQueryRelated = operationName => {
-    // true if any watched mutation cares about this query
-    const watchedMutationNames = Object.keys(this.mutationQueryResolverMap);
-    return watchedMutationNames.some(mutationName => {
-      const relevantQueryNames = Object.keys(this.mutationQueryResolverMap[mutationName]);
-      return relevantQueryNames.some(queryName => queryName === operationName);
-    });
+    const registeredQueryNames = this.mutationManager.getAllQueryNamesToUpdate();
+    return registeredQueryNames.some(queryName => queryName === operationName || false);
   }
   addRelatedQuery = (queryName, operation) => {
-    // add a queryName -> cachedQueryKey mapping to our map of cached queries to update
-    const existingCachedQueryKeys = (this.queriesToUpdate[queryName] || []);
-    const cachedQueryKey = { query: operation.query, variables: operation.variables };
-    this.queriesToUpdate[queryName] = [ ...existingCachedQueryKeys, cachedQueryKey ];
+    this.queriesToUpdate.addQuery(queryName, this.cache.createKey(operation));
   }
-  removeRelatedQuery = (queryName, cacheKey) => {
-    this.queriesToUpdate[queryName] = this.queriesToUpdate[queryName].filter(key => JSON.stringify(key) !== JSON.stringify(cacheKey));
+  removeRelatedQuery = (queryName, queryKey) => {
+    this.queriesToUpdate.removeQuery(queryName, queryKey);
   }
-
-  isMutationWatched = mutationName => this.mutationQueryResolverMap.hasOwnProperty(mutationName)
   getCachedQueryKeysToUpdate = mutationName => {
     // gets all the unique Query + QueryVariable cache keys used by the apollo-cache
-    const relevantQueryNames = Object.keys(this.mutationQueryResolverMap[mutationName] || {});
+    const relevantQueryNames = this.mutationManager.getQueryNamesToUpdate(mutationName);
     return relevantQueryNames.reduce((queryCacheKeyList, queryName) => {
-      const relevantQueryCacheKeys = this.queriesToUpdate[queryName] || [];
+      const relevantQueryCacheKeys = this.queriesToUpdate.getQueryKeysToUpdate(queryName);
       return [
         ...queryCacheKeyList,
         ...relevantQueryCacheKeys
@@ -80,16 +68,16 @@ export class WatchedMutationLink extends ApolloLink {
     }, []);
   }
 
-  updateQueryAfterMutation = (mutationOperation, mutationData, cacheKey) => {
-    const queryName = getQueryName(cacheKey.query);
-    const cachedQueryData = this.readFromCache(cacheKey);
+  updateQueryAfterMutation = (mutationOperation, mutationData, queryKey) => {
+    const queryName = getQueryName(queryKey.query);
+    const cachedQueryData = this.cache.read(queryKey);
     if (!cachedQueryData) {
       // we failed reading from the cache so there's nothing to update, probably it was invalidated outside of this link, we should remove it from our queries to update
-      this.removeRelatedQuery(queryName, cacheKey);
+      this.removeRelatedQuery(queryName, queryKey);
       return;
     }
     const mutationName = getQueryName(mutationOperation.query);
-    const updateQueryCb = this.mutationQueryResolverMap[mutationName][queryName];
+    const updateQueryCb = this.mutationManager.getUpdateFn(mutationName, queryName);
     const updatedData = updateQueryCb({
       mutation: {
         name: mutationName,
@@ -98,39 +86,85 @@ export class WatchedMutationLink extends ApolloLink {
       },
       query: {
         name: queryName,
-        variables: cacheKey.variables,
+        variables: queryKey.variables,
         result: cachedQueryData
       }
     });
     if (updatedData) {
-      this.writeToCache(cacheKey, updatedData);
+      this.cache.write(queryKey, updatedData);
     } else {
-      this.debugLog({ message: 'Success --- We did NOT receive anything new to write to the cache so we will not do anything', cacheKey });
+      this.debugLog({
+        message: 'We did NOT receive anything new to write to the cache so we will not do anything',
+        cacheKey: queryKey
+      });
     }
+  }
+  updateQueriesAfterMutation = (operation, operationName, result) => {
+    const cachedQueryToUpdateKeys = this.getCachedQueryKeysToUpdate(operationName);
+    cachedQueryToUpdateKeys.forEach(queryKey => {
+      this.debugLog({
+        message: 'Found a cached query related to this successful mutation, this Link will invoke the associated callback',
+        mutationName: operationName
+      });
+      this.updateQueryAfterMutation(operation, result, queryKey);
+    });
+  }
+
+  addOptimisticRequest = (operationName) => {
+    const cachedQueryToUpdateKeys = this.getCachedQueryKeysToUpdate(operationName);
+    cachedQueryToUpdateKeys.forEach(queryKey => {
+      const currentCachedState = this.cache.read(queryKey);
+      this.inflightOptimisticRequests.set(queryKey, currentCachedState);
+      this.debugLog({
+        message: 'Added a cached query in case we need to revert it after an optimistic error',
+        mutationName: operationName
+      });
+    });
+  }
+  clearOptimisticRequest = query => {
+    this.inflightOptimisticRequests.set(query, null);
+  }
+  revertOptimisticRequest = (operationName) => {
+    const cachedQueryToUpdateKeys = this.getCachedQueryKeysToUpdate(operationName);
+    cachedQueryToUpdateKeys.forEach(query => {
+      const previousCachedState = this.inflightOptimisticRequests.get(query);
+      if (previousCachedState) {
+        this.cache.write(query, previousCachedState);
+        this.debugLog({
+          message: 'Reverted an optimistic request after an error',
+          afterRevert: previousCachedState,
+          mutationName: operationName
+        });
+      }
+      this.clearOptimisticRequest(operationName);
+    });
   }
 
   request(operation, forward) {
     const observer = forward(operation);
     const definition = getMainDefinition(operation.query);
     const operationName = (definition && definition.name && definition.name.value) || '';
+    const context = operation.getContext();
+    if (isOptimistic(context) && this.mutationManager.isWatched(operationName)) {
+      this.addOptimisticRequest(operationName);
+      this.updateQueriesAfterMutation(operation, operationName, context.optimisticResponse);
+    }
 
     return observer.map(result => {
       if (isSuccessfulQuery(definition.operation, result) && this.isQueryRelated(operationName)) {
         // for every successful query, if any watched mutations care about it, store the cacheKey to update it later
-        this.debugLog({ message: 'Success --- Found a successful query related to a watched mutation', relatedQueryName: operationName });
+        this.debugLog({ message: 'Found a successful query related to a watched mutation', relatedQueryName: operationName });
         this.addRelatedQuery(operationName, operation);
       }
-      else if (isSuccessfulMutation(definition.operation, result) && this.isMutationWatched(operationName)) {
-        // for every successful mutation, look up the cachedQueryKeys the mutation cares about, and invoke the update callback for each one
-        const cachedQueryToUpdateKeys = this.getCachedQueryKeysToUpdate(operationName);
-        cachedQueryToUpdateKeys.forEach(cacheKey => {
-          this.debugLog({
-            message: 'Success --- Found a cached query related to this successful mutation, this Link will invoke the associated callback',
-            cacheKey,
-            mutationName: operationName
-          });
-          this.updateQueryAfterMutation(operation, result, cacheKey);
-        });
+      else if (isSuccessfulMutation(definition.operation, result) && this.mutationManager.isWatched(operationName)) {
+        if (isOptimistic(context)) {
+          this.clearOptimisticRequest(operationName);
+        } else {
+          // for every successful mutation, look up the cachedQueryKeys the mutation cares about, and invoke the update callback for each one
+          this.updateQueriesAfterMutation(operation, operationName, result);
+        }
+      } else if (isFailedMutation(definition.operation, result) && this.mutationManager.isWatched(operationName)) {
+        this.revertOptimisticRequest(operationName);
       }
       return result;
     });

--- a/src/inflight-request-manager.js
+++ b/src/inflight-request-manager.js
@@ -4,7 +4,7 @@ export const createInflightRequestManager = () => {
   const inflightRequests = {};
 
   return {
-    get: queryKey => inflightRequests[JSON.stringify(queryKey)],
+    getBeforeState: queryKey => inflightRequests[JSON.stringify(queryKey)],
     set: (queryKey, result) => {
       inflightRequests[JSON.stringify(queryKey)] = result;
     }

--- a/src/inflight-request-manager.js
+++ b/src/inflight-request-manager.js
@@ -1,0 +1,12 @@
+export const createInflightRequestManager = () => {
+  // used to keep track of prior cache states that we may have to revert after an optimistic error.
+  // structured as { JSON.stringify(cacheKey): cached_result }]
+  const inflightRequests = {};
+
+  return {
+    get: queryKey => inflightRequests[JSON.stringify(queryKey)],
+    set: (queryKey, result) => {
+      inflightRequests[JSON.stringify(queryKey)] = result;
+    }
+  };
+};

--- a/src/mutations-to-update-manager.js
+++ b/src/mutations-to-update-manager.js
@@ -2,12 +2,13 @@ export const createMutationsManager = mutationQueryResolverMap => {
   // used to look up mutations to watch, what queries each mutation is related to, and what callbacks to call for each query
 
   const getMutationNames = () => Object.keys(mutationQueryResolverMap);
-  const getQueryNamesToUpdate = mutationName => {
+  const getRegisteredQueryNames = mutationName => {
     return Object.keys(mutationQueryResolverMap[mutationName] || {})
   };
-  const getAllQueryNamesToUpdate = () => {
+  const getAllRegisteredQueryNames = () => {
+    // across all watched mutations
     return getMutationNames().reduce((queryNames, mutationName) => {
-      queryNames.push(...getQueryNamesToUpdate(mutationName));
+      queryNames.push(...getRegisteredQueryNames(mutationName));
       return queryNames;
     }, []);
   };
@@ -15,8 +16,8 @@ export const createMutationsManager = mutationQueryResolverMap => {
   return {
     isWatched: mutationName => mutationQueryResolverMap.hasOwnProperty(mutationName),
     getMutationNames,
-    getQueryNamesToUpdate,
-    getAllQueryNamesToUpdate,
+    getRegisteredQueryNames,
+    getAllRegisteredQueryNames,
     getUpdateFn: (mutationName, queryName) => mutationQueryResolverMap[mutationName][queryName] || (() => {})
   };
 };

--- a/src/mutations-to-update-manager.js
+++ b/src/mutations-to-update-manager.js
@@ -1,0 +1,22 @@
+export const createMutationsManager = mutationQueryResolverMap => {
+  // used to look up mutations to watch, what queries each mutation is related to, and what callbacks to call for each query
+
+  const getMutationNames = () => Object.keys(mutationQueryResolverMap);
+  const getQueryNamesToUpdate = mutationName => {
+    return Object.keys(mutationQueryResolverMap[mutationName] || {})
+  };
+  const getAllQueryNamesToUpdate = () => {
+    return getMutationNames().reduce((queryNames, mutationName) => {
+      queryNames.push(...getQueryNamesToUpdate(mutationName));
+      return queryNames;
+    }, []);
+  };
+
+  return {
+    isWatched: mutationName => mutationQueryResolverMap.hasOwnProperty(mutationName),
+    getMutationNames,
+    getQueryNamesToUpdate,
+    getAllQueryNamesToUpdate,
+    getUpdateFn: (mutationName, queryName) => mutationQueryResolverMap[mutationName][queryName] || (() => {})
+  };
+};

--- a/src/queries-to-update-manager.js
+++ b/src/queries-to-update-manager.js
@@ -12,7 +12,7 @@ export const createQueryKeyManager = () => {
     removeQuery: (queryName, queryKey) => {
       queriesToUpdate[queryName] = getQueryKeysToUpdate(queryName).filter(key => JSON.stringify(key) !== JSON.stringify(queryKey));
     },
-    hasQueryToUpdate: queryName => queriesToUpdate.hasOwnProperty(queryName),
+    hasQueryToUpdate: queryName => getQueryKeysToUpdate(queryName).length > 0,
     getQueryKeysToUpdate
   };
 }

--- a/src/queries-to-update-manager.js
+++ b/src/queries-to-update-manager.js
@@ -1,0 +1,18 @@
+export const createQueryKeyManager = () => {
+  // used to keep track of unique QueryName + QueryCacheKey combinations
+  // structured as { Query: [cache_key_1, cache_key_2, ...] }
+  const queriesToUpdate = {};
+
+  const getQueryKeysToUpdate = queryName => queriesToUpdate[queryName] || [];
+
+  return {
+    addQuery: (queryName, queryKey) => {
+      queriesToUpdate[queryName] = [...getQueryKeysToUpdate(queryName), queryKey];
+    },
+    removeQuery: (queryName, queryKey) => {
+      queriesToUpdate[queryName] = getQueryKeysToUpdate(queryName).filter(key => JSON.stringify(key) !== JSON.stringify(queryKey));
+    },
+    hasQueryToUpdate: queryName => queriesToUpdate.hasOwnProperty(queryName),
+    getQueryKeysToUpdate
+  };
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,25 +13,3 @@ export const getQueryName = query => {
   const queryDefinition = getMainDefinition(query);
   return (queryDefinition && queryDefinition.name && queryDefinition.name.value) || '';
 };
-
-export const getLinkArgs = (...args) => {
-  if (args.length) {
-    if (args.length === 1) {
-      // recommended constructor api
-      return {
-        ...args[0],
-        mutationQueryResolverMap: args[0].map
-      };
-    } else {
-      // try and be backwards compatible with 0.1.0
-      return {
-        cache: args[0],
-        mutationQueryResolverMap: args[1],
-        debug: args[2],
-        readOnly: args[3]
-      };
-    }
-  }
-
-  throw new Error('WatchedMutationLink requires input in the form { cache, map, debug, readOnly }');
-};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,37 @@
 import { getMainDefinition } from 'apollo-utilities';
 
-const isQuery = operation => operation === 'query';
-const isMutation = operation => operation === 'mutation';
-const isSuccessful = result => result.data && !result.data.error;
+export const isQuery = operation => operation === 'query';
+export const isMutation = operation => operation === 'mutation';
+export const isSuccessful = result => result.data && !result.data.error;
 export const isSuccessfulQuery = (operation, result) => isQuery(operation) && isSuccessful(result);
 export const isSuccessfulMutation = (operation, result) => isMutation(operation) && isSuccessful(result);
+export const isFailedMutation = (operation, result) => isMutation(operation) && !isSuccessful(result);
+
+export const isOptimistic = context => !!context.optimisticResponse;
 
 export const getQueryName = query => {
   const queryDefinition = getMainDefinition(query);
   return (queryDefinition && queryDefinition.name && queryDefinition.name.value) || '';
-}
+};
+
+export const getLinkArgs = (...args) => {
+  if (args.length) {
+    if (args.length === 1) {
+      // recommended constructor api
+      return {
+        ...args[0],
+        mutationQueryResolverMap: args[0].map
+      };
+    } else {
+      // try and be backwards compatible with 0.1.0
+      return {
+        cache: args[0],
+        mutationQueryResolverMap: args[1],
+        debug: args[2],
+        readOnly: args[3]
+      };
+    }
+  }
+
+  throw new Error('WatchedMutationLink requires input in the form { cache, map, debug, readOnly }');
+};


### PR DESCRIPTION
The way it should work:
- the associated callback is invoked immediately upon seeing an optimistic response
- any error for that mutation will trigger a reversion of the cache update from ☝️ 
- any success will trigger nothing since we already updated the cache optimistically.