### PR TITLE
Take advantage of graphQLResultHasError

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,11 @@
-import { getMainDefinition } from 'apollo-utilities';
+import {
+  getMainDefinition,
+  graphQLResultHasError
+} from 'apollo-utilities';
 
 export const isQuery = operation => operation === 'query';
 export const isMutation = operation => operation === 'mutation';
-export const isSuccessful = result => result.data && !result.data.error && !result.errors;
+export const isSuccessful = result => !graphQLResultHasError(result);
 export const isSuccessfulQuery = (operation, result) => isQuery(operation) && isSuccessful(result);
 export const isSuccessfulMutation = (operation, result) => isMutation(operation) && isSuccessful(result);
 export const isFailedMutation = (operation, result) => isMutation(operation) && !isSuccessful(result);


### PR DESCRIPTION
Taking advantage of apollo-utilities where we can rather than my check for `isSuccessful`